### PR TITLE
increase wait for daemonset timeout

### DIFF
--- a/deploy/kubernetes-distributed/deploy.sh
+++ b/deploy/kubernetes-distributed/deploy.sh
@@ -251,7 +251,7 @@ for i in $(ls ${BASE_DIR}/hostpath/*.yaml | sort); do
 done
 
 wait_for_daemonset () {
-    retries=10
+    retries=20
     while [ $retries -ge 0 ]; do
         ready=$(kubectl get -n $1 daemonset $2 -o jsonpath="{.status.numberReady}")
         required=$(kubectl get -n $1 daemonset $2 -o jsonpath="{.status.desiredNumberScheduled}")
@@ -259,7 +259,7 @@ wait_for_daemonset () {
             return 0
         fi
         retries=$((retries - 1))
-        sleep 3
+        sleep 5
     done
     return 1
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: This PR increases the wait for daemonset timeout to 100 seconds instead of 30. One my machine the daemonset takes approximately 1 minute to become ready.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
